### PR TITLE
Scenario detail layout

### DIFF
--- a/client/components/Cohorts/Cohort.css
+++ b/client/components/Cohorts/Cohort.css
@@ -35,7 +35,7 @@
   align-items: center;
   display: grid !important;
   grid-column-gap: 1rem;
-  grid-template-columns: 2fr 1fr;
+  grid-template-columns: min-content 2fr 1fr;
   width: 100% !important;
 }
 

--- a/client/components/Cohorts/Cohort.css
+++ b/client/components/Cohorts/Cohort.css
@@ -14,15 +14,12 @@
 }
 
 .c__section {
-  margin-bottom: 3rem;
+  margin: 0 auto 3rem auto;
+  max-width: 70rem;
 }
 
-.c__header {
-  margin-bottom: 0 !important;
-}
-
-.c__subheader {
-  font-size: 1.2rem;
+.c__scenario-header-num span {
+  font-weight: bold;
 }
 
 .c__cohort-url .ui.button {
@@ -34,11 +31,48 @@
   width: 100%;
 }
 
+.c__scenario-card {
+  align-items: center;
+  display: grid !important;
+  grid-column-gap: 1rem;
+  grid-template-columns: 2fr 1fr;
+  width: 100% !important;
+}
+
+.c__scenario-card .meta:not(:empty) {
+  margin-top: 1rem;
+}
+
+.c__scenario-card.ui.card .meta * {
+  margin-bottom: 0.5rem;
+}
+
+.c__scenario-extra {
+  padding: 1rem;
+}
+
+.c__scenario-extra button {
+  width: 100%;
+}
+
+.c__scenario-list {
+  padding: 0;
+}
+
+.c__scenario-container {
+  background-color: var(--color-gray);
+  padding: 1rem;
+}
+
 @media only screen and (max-width: 767px) {
   .ui.container.c__table-container {
     width: auto !important;
     margin-left: 0em !important;
     margin-right: 0em !important;
+  }
+
+  .c__scenario-card {
+    display: block !important;
   }
 }
 

--- a/client/components/Cohorts/Cohort.css
+++ b/client/components/Cohorts/Cohort.css
@@ -13,6 +13,19 @@
   margin-bottom: 1rem;
 }
 
+.c__cohort-url {
+  margin-bottom: 1rem;
+}
+
+.c__cohort-url .ui.button {
+  display: block;
+  margin-top: 1rem;
+}
+
+.c__cohort-url .ui.input input[type="text"] {
+  width: 100%;
+}
+
 @media only screen and (max-width: 767px) {
   .ui.container.c__table-container {
     width: auto !important;

--- a/client/components/Cohorts/Cohort.css
+++ b/client/components/Cohorts/Cohort.css
@@ -13,13 +13,21 @@
   margin-bottom: 1rem;
 }
 
-.c__cohort-url {
-  margin-bottom: 1rem;
+.c__section {
+  margin-bottom: 3rem;
+}
+
+.c__header {
+  margin-bottom: 0 !important;
+}
+
+.c__subheader {
+  font-size: 1.2rem;
 }
 
 .c__cohort-url .ui.button {
   display: block;
-  margin-top: 1rem;
+  margin-top: 0.5rem;
 }
 
 .c__cohort-url .ui.input input[type="text"] {

--- a/client/components/Cohorts/Cohort.jsx
+++ b/client/components/Cohorts/Cohort.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { Icon, Menu, Segment, Title } from '@components/UI';
+import { Button, Icon, Input, Menu, Segment, Title } from '@components/UI';
 import copy from 'copy-text-to-clipboard';
 import Storage from '@utils/Storage';
 import { getCohort, linkUserToCohort } from '@actions/cohort';
@@ -172,16 +172,20 @@ export class Cohort extends React.Component {
     // Everytime there is a render, save the state.
     Storage.set(this.sessionKey, { activeTabKey, tabs });
 
-    const menuItemCopyUrl = (
-      <Menu.Item.Tabbable
-        key="menu-item-account-administration"
+    const menuItemShowCohortUrl = (
+      <Input label="Cohort url" size="big" type="text" defaultValue={url} />
+    );
+
+    const menuItemCopyCohortUrl = (
+      <Button
+        icon
+        labelPosition="left"
+        size="small"
         onClick={onCohortUrlCopyClick}
       >
-        <Icon.Group className="em__icon-group-margin">
-          <Icon name="clipboard outline" />
-        </Icon.Group>
+        <Icon name="clipboard outline" color="blue" />
         Copy cohort link to clipboard
-      </Menu.Item.Tabbable>
+      </Button>
     );
 
     return (
@@ -214,9 +218,9 @@ export class Cohort extends React.Component {
         {activeTabKey === 'cohort' ? (
           <Segment attached="bottom">
             {isFacilitator ? (
-              <Menu icon borderless>
-                {menuItemCopyUrl}
-              </Menu>
+              <div className="c__cohort-url">
+                {menuItemShowCohortUrl} {menuItemCopyCohortUrl}
+              </div>
             ) : null}
             <CohortScenarios
               key="cohort-scenarios"

--- a/client/components/Cohorts/Cohort.jsx
+++ b/client/components/Cohorts/Cohort.jsx
@@ -2,7 +2,15 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { Button, Icon, Input, Menu, Segment, Title } from '@components/UI';
+import {
+  Button,
+  Header,
+  Icon,
+  Input,
+  Menu,
+  Segment,
+  Title
+} from '@components/UI';
 import copy from 'copy-text-to-clipboard';
 import Storage from '@utils/Storage';
 import { getCohort, linkUserToCohort } from '@actions/cohort';
@@ -218,16 +226,24 @@ export class Cohort extends React.Component {
         {activeTabKey === 'cohort' ? (
           <Segment attached="bottom">
             {isFacilitator ? (
-              <div className="c__cohort-url">
+              <section className="c__section c__cohort-url">
                 {menuItemShowCohortUrl} {menuItemCopyCohortUrl}
-              </div>
+              </section>
             ) : null}
-            <CohortScenarios
-              key="cohort-scenarios"
-              id={cohort.id}
-              authority={authority}
-              onClick={onClick}
-            />
+            <section className="c__section">
+              <Header className="c__header" as="h2">
+                Cohort scenarios
+              </Header>
+              <p className="c__subheader">
+                Manage your assigned scenarios and see your cohort responses.
+              </p>
+              <CohortScenarios
+                key="cohort-scenarios"
+                id={cohort.id}
+                authority={authority}
+                onClick={onClick}
+              />
+            </section>
             {isFacilitator ? (
               <CohortParticipants
                 key="cohort-participants"

--- a/client/components/Cohorts/Cohort.jsx
+++ b/client/components/Cohorts/Cohort.jsx
@@ -234,9 +234,6 @@ export class Cohort extends React.Component {
               <Header className="c__header" as="h2">
                 Cohort scenarios
               </Header>
-              <p className="c__subheader">
-                Manage your assigned scenarios and see your cohort responses.
-              </p>
               <CohortScenarios
                 key="cohort-scenarios"
                 id={cohort.id}


### PR DESCRIPTION
This is a PR to address some of the layout changes on the cohort detail page. I wouldn't consider this "feature complete" as it relies on a few items (re: editing scenario selection in a modal as designed in the Figma). This was more to start laying out the design of these cards (as well as a few other items on the page). For example, the checkmarks are still in place, but I imagine that this scenario list would only show the selected scenarios and so a checkmark isn't needed.

Let me know thoughts. I can also re-do this to leave out the scenario card design for now (and put the other page changes into place) and we can come back to it when we have other items ready to go.