### PR TITLE
Show cohort status

### DIFF
--- a/client/components/Cohorts/Cohort.css
+++ b/client/components/Cohorts/Cohort.css
@@ -306,3 +306,11 @@
 .icon-primary > i {
   color: #853D61;
 }
+
+.ui.card .c-card__status {
+  color: #000 !important;
+  font-size: 0.9rem !important;
+  font-weight: bold;
+  margin-bottom: 1rem !important;
+  text-align: right;
+}

--- a/client/components/Cohorts/Cohort.css
+++ b/client/components/Cohorts/Cohort.css
@@ -314,3 +314,10 @@
   margin-bottom: 1rem !important;
   text-align: right;
 }
+
+.c__primary-sidenav {
+  background: transparent !important;
+  border: 0 !important;
+  color: #853D61 !important;
+  padding: 0 !important;
+}

--- a/client/components/Cohorts/CohortCard.jsx
+++ b/client/components/Cohorts/CohortCard.jsx
@@ -11,7 +11,7 @@ import CohortScenarioLabels from '@components/Cohorts/CohortScenarioLabels';
 
 export const CohortCard = props => {
   const { cohort, roles, user } = props;
-  const { id, created_at, deleted_at, updated_at, name } = cohort;
+  const { id, created_at, deleted_at, updated_at, name, is_archived } = cohort;
   const yourRoles = rolesToHumanReadableString('cohort', roles);
   const updatedfromNow = Moment(updated_at || created_at).fromNow();
   const updatedCalendar = Moment(updated_at || created_at).calendar();
@@ -29,6 +29,8 @@ export const CohortCard = props => {
     props.history.push(`/cohort/${id}`);
   };
 
+  const cohortStatus = is_archived ? 'Archived' : 'Active';
+
   const restoreCohort =
     deleted_at && user.is_super ? (
       <Card.Content extra>
@@ -41,6 +43,7 @@ export const CohortCard = props => {
   return (
     <Card className={cardClassName} key={id}>
       <Card.Content className="sc">
+        <Card.Meta className="c-card__status">{cohortStatus}</Card.Meta>
         <Card.Header>
           <NavLink to={`/cohort/${id}`}>{name}</NavLink>
         </Card.Header>

--- a/client/components/Cohorts/index.jsx
+++ b/client/components/Cohorts/index.jsx
@@ -13,6 +13,7 @@ import {
   Header,
   Icon,
   Input,
+  List,
   Menu,
   Pagination,
   Segment,
@@ -318,9 +319,35 @@ export class Cohorts extends React.Component {
       />
     ) : null;
 
+    const cohortSideNav = (
+      <List relaxed size="big">
+        <List.Item>
+          <List.Header className="c__primary-sidenav" as="button">
+            Active
+          </List.Header>
+          <List.Description>
+            Cohorts that are currently running.
+          </List.Description>
+        </List.Item>
+        <List.Item>
+          <List.Header className="c__primary-sidenav" as="button">
+            Archived
+          </List.Header>
+          <List.Description>Cohorts no longer running.</List.Description>
+        </List.Item>
+      </List>
+    );
+
+    const cohortAuthorActions = (
+      <Fragment>
+        {createCohortButton}
+        {cohortSideNav}
+      </Fragment>
+    );
+
     const cohortPermissionActions = [
       permissions.includes('create_cohort')
-        ? createCohortButton
+        ? cohortAuthorActions
         : menuItemCountCohorts
     ];
 


### PR DESCRIPTION
This is a PR to show the cohort status on the cohort card per the design.

* Cohort status is shown on the card (active or archived)
* A static sidebar for active or archived cohorts

This is not a feature complete. Things still needed are:
* Default is only showing active cohorts in the list
* Clicking on either active or archived in the sidebar filters the cards accordingly