### PR TITLE
Add Dashboard to navigation links

### DIFF
--- a/client/routes/Navigation.jsx
+++ b/client/routes/Navigation.jsx
@@ -1,13 +1,14 @@
-import React, { Component, Fragment } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { NavLink, withRouter } from 'react-router-dom';
-import { endScenarioLock } from '@actions/scenario';
 import { Dropdown, Menu } from '@components/UI';
+import { NavLink, withRouter } from 'react-router-dom';
+import React, { Component, Fragment } from 'react';
+
 import Gate from '@components/Gate';
+import Layout from '@utils/Layout';
+import PropTypes from 'prop-types';
 import UserInvites from '@components/User/UserInvites';
 import UserMenu from '@components/User/UserMenu';
-import Layout from '@utils/Layout';
+import { connect } from 'react-redux';
+import { endScenarioLock } from '@actions/scenario';
 
 const restrictedNav = [
   {
@@ -87,6 +88,12 @@ class Navigation extends Component {
 
     const menuItemAuthorized = isLoggedIn ? menuItemsRequireLogin : null;
 
+    const menuItemDashboard = (
+      <Menu.Item.Tabbable aria-label="Dashboard" to="/dashboard" as={NavLink}>
+        Dashboard
+      </Menu.Item.Tabbable>
+    )
+
     // This is used as the dropdown trigger, in the top menu
     const menuItemScenarios = (
       <Menu.Item.Tabbable
@@ -141,6 +148,7 @@ class Navigation extends Component {
               trigger={menuItemGoTo}
             >
               <Dropdown.Menu>
+                {menuItemDashboard}
                 {menuItemScenarios}
                 {menuItemAuthorized}
               </Dropdown.Menu>
@@ -153,6 +161,7 @@ class Navigation extends Component {
         ) : (
           <Fragment>
             {menuItemBrandLogo}
+            {menuItemDashboard}
             {menuItemScenarios}
             {menuItemAuthorized}
             <Menu.Menu position="right">

--- a/client/routes/Routes.jsx
+++ b/client/routes/Routes.jsx
@@ -1,40 +1,40 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { Route, Switch } from 'react-router-dom';
-
-import Admin from '@components/Admin';
-import Chat from '@components/Chat';
-import JoinAs from '@components/Chat/JoinAs';
-import Cohort from '@components/Cohorts/Cohort';
-import Cohorts from '@components/Cohorts';
-import Gate from '@components/Gate';
-import CreateAccount from '@components/CreateAccount';
-import CreateAnonymousAccount from '@components/CreateAccount/CreateAnonymousAccount';
-import Downloads from '@components/Downloads';
-import Editor from '@components/Editor';
-import ForOhFor from '@components/ForOhFor';
-import History from '@components/History';
-import Login from '@components/Login';
-import LoginRoutePromptModal from '@components/Login/LoginRoutePromptModal';
-import ResetRoutePromptModal from '@components/Login/ResetRoutePromptModal';
-import Run from '@components/Run';
 import {
   CopyScenario,
-  UserDashboard,
-  Logout,
   InterceptAnonymizableRoute,
+  Logout,
   NewScenario,
   RedirectRouteForActiveSession,
   RedirectRouteForInactiveSession,
   ScenariosListAll,
   ScenariosListAuthor,
   ScenariosListCommunity,
-  ScenariosListOfficial
+  ScenariosListOfficial,
+  UserDashboard
 } from './RouteComponents';
-import UserSettings from '@components/User/UserSettings';
-import UserInvites from '@components/User/UserInvites';
+import { Route, Switch } from 'react-router-dom';
+
+import Admin from '@components/Admin';
+import Chat from '@components/Chat';
+import Cohort from '@components/Cohorts/Cohort';
+import Cohorts from '@components/Cohorts';
+import CreateAccount from '@components/CreateAccount';
+import CreateAnonymousAccount from '@components/CreateAccount/CreateAnonymousAccount';
+import Downloads from '@components/Downloads';
+import Editor from '@components/Editor';
+import ForOhFor from '@components/ForOhFor';
+import Gate from '@components/Gate';
+import History from '@components/History';
+import JoinAs from '@components/Chat/JoinAs';
+import Login from '@components/Login';
+import LoginRoutePromptModal from '@components/Login/LoginRoutePromptModal';
+import PropTypes from 'prop-types';
 import QueryString from '@utils/QueryString';
+import React from 'react';
+import ResetRoutePromptModal from '@components/Login/ResetRoutePromptModal';
+import Run from '@components/Run';
+import UserInvites from '@components/User/UserInvites';
+import UserSettings from '@components/User/UserSettings';
+import { connect } from 'react-redux';
 
 const makeEditorProps = (props = {}) => ({
   ...props,
@@ -96,6 +96,7 @@ const Routes = ({ isLoggedIn, user }) => {
   return (
     <Switch>
       <Route exact path="/" component={UserDashboard} />
+      <Route exact path="/dashboard" component={UserDashboard} />
 
       <InterceptAnonymizableRoute
         path="/invite/:status/:code"


### PR DESCRIPTION
Dashboard now appears immediately to the right of the logo. The logo links to "/" which is currently routed to dashboard, so clicking either the logo or the Dashboard link take you to the same place. This branch also routes "/dashboard" to the dashboard.

![Screen Shot 2022-05-10 at 4 56 09 PM](https://user-images.githubusercontent.com/6191896/167720448-fe2a180b-54be-49fe-a05a-b021ebfd602b.png)

https://app.asana.com/0/1199528021095056/1202199381153816/f

