### PR TITLE
Add config/dev-heroku secrets to default gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ yarn-error.log
 *.xlsx
 *.xls
 !test/load/payload/*.csv
+config/dev-heroku-secrets


### PR DESCRIPTION
Just a minor thing to make the onboarding process a little easier -- I assume these are supposed to be gitignore'd but please correct me if I'm wrong!