### PR TITLE
Dashboard content changes

### DIFF
--- a/client/components/Dashboard/Dashboard.css
+++ b/client/components/Dashboard/Dashboard.css
@@ -13,8 +13,7 @@
 }
 
 .dashboard ul,
-.dashboard ol {
-  list-style: none;
+.dashboard .ui.ordered.list {
   margin: 0;
   padding: 0;
 }
@@ -75,22 +74,18 @@
   grid-template-columns: repeat(auto-fill, minmax(min(20rem, 100%), 1fr));
 }
 
-.dashboard-grid--numbered {
-  counter-reset: list;
-}
-
-.dashboard-grid--numbered li {
-  counter-increment: list;
-}
-
 .dashboard-grid--numbered .dashboard-card::before {
   align-self: start;
   background-color: #f5f5f5;
   border-radius: 5px;
-  content: counter(list);
+  content: counter(ordered);
   font-weight: bold;
   margin-bottom: 0.5rem;
   padding: 0.5rem;
+}
+
+.ui.ordered.list.dashboard-grid--numbered .item:before {
+  content: "";
 }
 
 .dashboard-grid .dashboard-card {

--- a/client/components/Dashboard/Dashboard.css
+++ b/client/components/Dashboard/Dashboard.css
@@ -18,6 +18,10 @@
   padding: 0;
 }
 
+.dashboard ul {
+  list-style: none;
+}
+
 .dashboard h1 {
   border-bottom: 1px solid #c1c1b0;
 }

--- a/client/components/Dashboard/LearnByExample.jsx
+++ b/client/components/Dashboard/LearnByExample.jsx
@@ -20,8 +20,8 @@ const LearnByExample = () => {
     <Container fluid id="learn-by-example">
       <Header as="h2">Learn by example</Header>
       <Header.Subheader className="dashboard-subheader">
-        Run or copy example scenarios created by the team to learn all the
-        features of Teacher Moments.
+        Run or copy examples created by the team to explore the features of
+        Teacher Moments.
       </Header.Subheader>
       <Card.Group itemsPerRow="2" className="dashboard-card-group">
         {examples.map(scenario => {

--- a/client/components/Dashboard/index.jsx
+++ b/client/components/Dashboard/index.jsx
@@ -118,7 +118,7 @@ const QuickStartGuide = () => {
         <li>
           <Card className="dashboard-card">
             <p className="dashboard-card__title">Creating a Cohort</p>
-            <p>How to manage your classroom and discussions with cohorts.</p>
+            <p>How to manage your classroom and discussions with cohorts</p>
             <a
               className="dashboard-card__link"
               href="https://docs.google.com/presentation/d/1QM32ZAxT-NtRM7aInkqB7DKRweOWyQwluqgd79m352I/edit#slide=id.gf325c6b0ac_0_108"

--- a/client/components/Dashboard/index.jsx
+++ b/client/components/Dashboard/index.jsx
@@ -60,7 +60,7 @@ const QuickStartGuide = () => {
     <section id="quick-start-guide">
       <div className="dashboard-subheader">
         <h2>Quick start guide</h2>
-        <p>Onboard onto Teacher Moments using with step-by-step decks.</p>
+        <p>Learn to author and use Teacher Moments scenarios.</p>
       </div>
       <ol className="dashboard-grid dashboard-grid--numbered">
         <li>

--- a/client/components/Dashboard/index.jsx
+++ b/client/components/Dashboard/index.jsx
@@ -184,8 +184,8 @@ const Dashboard = () => {
         <div className="dashboard-main">
           {isParticipantOnly(user) && <AuthoringPermissionsNote />}
 
-          <RecentCohorts />
           <RecentScenarios />
+          <RecentCohorts />
           <LearnByExample />
           <QuickStartGuide />
           <GetInTouch />

--- a/client/components/Dashboard/index.jsx
+++ b/client/components/Dashboard/index.jsx
@@ -152,7 +152,10 @@ const QuickStartGuide = () => {
           Learn more about deeper features like branching and multiplayer
           scenarios in our resource center.
         </p>
-        <a className="dashboard-card__link" href="#">
+        <a
+          className="dashboard-card__link"
+          href="https://drive.google.com/drive/folders/1A3MxYpjPXSPndW3wMwAUXonZh6kFKYmG?usp=sharing"
+        >
           Go to resource center →
         </a>
       </Segment>

--- a/client/components/Dashboard/index.jsx
+++ b/client/components/Dashboard/index.jsx
@@ -66,7 +66,7 @@ const QuickStartGuide = () => {
         <li>
           <Card className="dashboard-card">
             <p className="dashboard-card__title">
-              What are digital clinical simulations?
+              What Are Digital Clinical Simulations?
             </p>
             <p>An overview of Teacher Moments and ELK</p>
             <a
@@ -79,7 +79,7 @@ const QuickStartGuide = () => {
         </li>
         <li>
           <Card className="dashboard-card">
-            <p className="dashboard-card__title">Authoring a scenario</p>
+            <p className="dashboard-card__title">Authoring a Scenario</p>
             <p>How to develop a basic scenario in Teacher Moments</p>
             <a
               className="dashboard-card__link"
@@ -105,7 +105,7 @@ const QuickStartGuide = () => {
         </li>
         <li>
           <Card className="dashboard-card">
-            <p className="dashboard-card__title">Authoring in more details</p>
+            <p className="dashboard-card__title">Authoring in More Detail</p>
             <p>A more detailed look at authoring scenarios for one player</p>
             <a
               className="dashboard-card__link"
@@ -117,7 +117,7 @@ const QuickStartGuide = () => {
         </li>
         <li>
           <Card className="dashboard-card">
-            <p className="dashboard-card__title">Creating a cohort</p>
+            <p className="dashboard-card__title">Creating a Cohort</p>
             <p>How to manage your classroom and discussions with cohorts.</p>
             <a
               className="dashboard-card__link"
@@ -129,7 +129,7 @@ const QuickStartGuide = () => {
         </li>
         <li>
           <Card className="dashboard-card">
-            <p className="dashboard-card__title">Teaching with simulations</p>
+            <p className="dashboard-card__title">Teaching with Simulations</p>
             <p>
               How to use responses from your cohort to facilitate discussion
             </p>

--- a/client/components/Dashboard/index.jsx
+++ b/client/components/Dashboard/index.jsx
@@ -117,13 +117,11 @@ const QuickStartGuide = () => {
         </li>
         <li>
           <Card className="dashboard-card">
-            <p className="dashboard-card__title">Teaching with simulations</p>
-            <p>
-              How to use responses from your cohort to facilitate discussion
-            </p>
+            <p className="dashboard-card__title">Creating a cohort</p>
+            <p>How to manage your classroom and discussions with cohorts.</p>
             <a
               className="dashboard-card__link"
-              href="https://docs.google.com/presentation/d/1sKfDO0J6t4uxYWM-Bi1r_UJifPFOG1u_1U2hHEVsuzc/edit?usp=sharing"
+              href="https://docs.google.com/presentation/d/1QM32ZAxT-NtRM7aInkqB7DKRweOWyQwluqgd79m352I/edit#slide=id.gf325c6b0ac_0_108"
             >
               Go to guide →
             </a>
@@ -131,11 +129,13 @@ const QuickStartGuide = () => {
         </li>
         <li>
           <Card className="dashboard-card">
-            <p className="dashboard-card__title">Creating a cohort</p>
-            <p>How to manage your classroom and discussions with cohorts.</p>
+            <p className="dashboard-card__title">Teaching with simulations</p>
+            <p>
+              How to use responses from your cohort to facilitate discussion
+            </p>
             <a
               className="dashboard-card__link"
-              href="https://docs.google.com/presentation/d/1QM32ZAxT-NtRM7aInkqB7DKRweOWyQwluqgd79m352I/edit#slide=id.gf325c6b0ac_0_108"
+              href="https://docs.google.com/presentation/d/1sKfDO0J6t4uxYWM-Bi1r_UJifPFOG1u_1U2hHEVsuzc/edit?usp=sharing"
             >
               Go to guide →
             </a>

--- a/client/components/Dashboard/index.jsx
+++ b/client/components/Dashboard/index.jsx
@@ -65,9 +65,7 @@ const QuickStartGuide = () => {
       <ol className="dashboard-grid dashboard-grid--numbered">
         <li>
           <Card className="dashboard-card">
-            <p className="dashboard-card__title">
-              What Are Digital Clinical Simulations?
-            </p>
+            <p className="dashboard-card__title">What Is Teacher Moments?</p>
             <p>An overview of Teacher Moments and ELK</p>
             <a
               className="dashboard-card__link"

--- a/client/components/Dashboard/index.jsx
+++ b/client/components/Dashboard/index.jsx
@@ -1,6 +1,13 @@
 import './Dashboard.css';
 
-import { Card, Container } from '@components/UI';
+import {
+  Card,
+  Container,
+  Divider,
+  Header,
+  List,
+  Segment
+} from '@components/UI';
 
 import LearnByExample from './LearnByExample';
 import React from 'react';
@@ -57,13 +64,13 @@ const AuthoringPermissionsNote = () => {
 
 const QuickStartGuide = () => {
   return (
-    <section id="quick-start-guide">
-      <div className="dashboard-subheader">
-        <h2>Quick start guide</h2>
-        <p>Learn to author and use Teacher Moments scenarios.</p>
-      </div>
-      <ol className="dashboard-grid dashboard-grid--numbered">
-        <li>
+    <Container fluid id="quick-start-guide">
+      <Header as="h2">Quick start guide</Header>
+      <Header.Subheader className="dashboard-subheader">
+        Learn to author and use Teacher Moments scenarios.
+      </Header.Subheader>
+      <List ordered className="dashboard-grid dashboard-grid--numbered">
+        <List.Item>
           <Card className="dashboard-card">
             <p className="dashboard-card__title">What Is Teacher Moments?</p>
             <p>An overview of Teacher Moments and ELK</p>
@@ -74,8 +81,8 @@ const QuickStartGuide = () => {
               Go to guide →
             </a>
           </Card>
-        </li>
-        <li>
+        </List.Item>
+        <List.Item>
           <Card className="dashboard-card">
             <p className="dashboard-card__title">Authoring a Scenario</p>
             <p>How to develop a basic scenario in Teacher Moments</p>
@@ -86,8 +93,8 @@ const QuickStartGuide = () => {
               Go to guide →
             </a>
           </Card>
-        </li>
-        <li>
+        </List.Item>
+        <List.Item>
           <Card className="dashboard-card">
             <p className="dashboard-card__title">
               Authoring the Different Components
@@ -100,8 +107,8 @@ const QuickStartGuide = () => {
               Go to guide →
             </a>
           </Card>
-        </li>
-        <li>
+        </List.Item>
+        <List.Item>
           <Card className="dashboard-card">
             <p className="dashboard-card__title">Authoring in More Detail</p>
             <p>A more detailed look at authoring scenarios for one player</p>
@@ -112,8 +119,8 @@ const QuickStartGuide = () => {
               Go to guide →
             </a>
           </Card>
-        </li>
-        <li>
+        </List.Item>
+        <List.Item>
           <Card className="dashboard-card">
             <p className="dashboard-card__title">Creating a Cohort</p>
             <p>How to manage your classroom and discussions with cohorts</p>
@@ -124,8 +131,8 @@ const QuickStartGuide = () => {
               Go to guide →
             </a>
           </Card>
-        </li>
-        <li>
+        </List.Item>
+        <List.Item>
           <Card className="dashboard-card">
             <p className="dashboard-card__title">Teaching with Simulations</p>
             <p>
@@ -138,9 +145,9 @@ const QuickStartGuide = () => {
               Go to guide →
             </a>
           </Card>
-        </li>
-      </ol>
-      <div className="dashboard-cta">
+        </List.Item>
+      </List>
+      <Segment padded secondary className="dashboard-cta">
         <p>
           Learn more about deeper features like branching and multiplayer
           scenarios in our resource center.
@@ -148,26 +155,25 @@ const QuickStartGuide = () => {
         <a className="dashboard-card__link" href="#">
           Go to resource center →
         </a>
-      </div>
-    </section>
+      </Segment>
+    </Container>
   );
 };
 
 const GetInTouch = () => {
   return (
-    <section id="get-in-touch">
-      <div className="dashboard-subheader">
-        <h2>Get in touch</h2>
-      </div>
-      <div className="dashboard-cta">
+    <Container fluid id="get-in-touch">
+      <Header as="h2">Get in touch</Header>
+      <Divider />
+      <Segment secondary padded className="dashboard-cta">
         <p>
           Email us at{' '}
           <a href="mailto:teachermoments@mit.edu">teachermoments@mit.edu</a> for
           any questions using Teacher Moments or to join our regular community
           events for synchronous learning.
         </p>
-      </div>
-    </section>
+      </Segment>
+    </Container>
   );
 };
 


### PR DESCRIPTION
- New subheader under Learn by examples https://app.asana.com/0/1199528021095056/1202324225921886
- Change title of first quick start guide card https://app.asana.com/0/1199528021095056/1202324225921884
- New subheader under quick start guide header https://app.asana.com/0/1199528021095056/1202324225921882
- Move Recent Scenarios above Recent Cohorts https://app.asana.com/0/1199528021095056/1202324225921876
- Remove period from 'create a cohort' card description https://app.asana.com/0/1199528021095056/1202324225921874
- Title case quick start guide item titles https://app.asana.com/0/1199528021095056/1202324225921872
- Switch quick start links 5 and 6 https://app.asana.com/0/1199528021095056/1202324225921870