### PR TITLE
Fix dashboard sidenav links

### DIFF
--- a/client/components/Dashboard/Dashboard.css
+++ b/client/components/Dashboard/Dashboard.css
@@ -40,9 +40,6 @@
     align-self: start;
     background-color: #f6f6ee;
     border-radius: 5px;
-    display: flex;
-    flex-direction: column;
-    gap: 2rem;
     padding: 1rem;
     position: sticky;
     top: 1rem;
@@ -55,14 +52,9 @@
 
 .dashboard-sidenav__subtitle {
   font-size: 1.25rem;
-  margin-bottom: 0.5rem;
 }
 
-.dashboard-sidenav li:not(:last-of-type) {
-  margin-bottom: 0.5rem;
-}
-
-.dashboard-sidenav li a {
+.dashboard-sidenav .item a {
   color: var(--color-primary);
   font-weight: bold;
 }

--- a/client/components/Dashboard/index.jsx
+++ b/client/components/Dashboard/index.jsx
@@ -6,9 +6,11 @@ import {
   Divider,
   Header,
   List,
+  Menu,
   Segment
 } from '@components/UI';
 
+import { HashLink } from 'react-router-hash-link';
 import LearnByExample from './LearnByExample';
 import React from 'react';
 import RecentCohorts from './RecentCohorts';
@@ -19,33 +21,33 @@ import { useSelector } from 'react-redux';
 
 const SideNav = () => {
   return (
-    <aside className="dashboard-sidenav">
-      <section className="dashboard-sidenav__section">
-        <p className="dashboard-sidenav__subtitle">Your tools</p>
-        <ul>
-          <li>
-            <a href="#recent-scenarios">Recent scenarios</a>
-          </li>
-          <li>
-            <a href="#recent-cohorts">Recent cohorts</a>
-          </li>
-        </ul>
-      </section>
-      <section className="dashboard-sidenav__section">
-        <p className="dashboard-sidenav__subtitle">Knowledge Center</p>
-        <ul>
-          <li>
-            <a href="#learn-by-example">Learn by example</a>
-          </li>
-          <li>
-            <a href="#quick-start-guide">Quick start guide</a>
-          </li>
-          <li>
-            <a href="#get-in-touch">Get in touch</a>
-          </li>
-        </ul>
-      </section>
-    </aside>
+    <Container fluid className="dashboard-sidenav">
+      <Menu text vertical className="dashboard-sidenav__section">
+        <Menu.Item header className="dashboard-sidenav__subtitle">
+          Your tools
+        </Menu.Item>
+        <Menu.Item>
+          <HashLink to="#recent-scenarios">Recent scenarios</HashLink>
+        </Menu.Item>
+        <Menu.Item>
+          <HashLink to="#recent-cohorts">Recent cohorts</HashLink>
+        </Menu.Item>
+      </Menu>
+      <Menu text vertical className="dashboard-sidenav__section">
+        <Menu.Item header className="dashboard-sidenav__subtitle">
+          Knowledge Center
+        </Menu.Item>
+        <Menu.Item>
+          <HashLink to="#learn-by-example">Learn by example</HashLink>
+        </Menu.Item>
+        <Menu.Item>
+          <HashLink to="#quick-start-guide">Quick start guide</HashLink>
+        </Menu.Item>
+        <Menu.Item>
+          <HashLink to="#get-in-touch">Get in touch</HashLink>
+        </Menu.Item>
+      </Menu>
+    </Container>
   );
 };
 

--- a/client/package.json
+++ b/client/package.json
@@ -114,6 +114,7 @@
     "react-resize-aware": "^3.1.0",
     "react-rnd": "^10.2.4",
     "react-router-dom": "^5.0.1",
+    "react-router-hash-link": "^2.4.3",
     "react-semantic-toasts": "^0.6.5",
     "react-semantic-ui-range": "^0.7.0",
     "react-simple-timefield": "^3.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16661,6 +16661,13 @@ react-router-dom@^5.0.1:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
+react-router-hash-link@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/react-router-hash-link/-/react-router-hash-link-2.4.3.tgz#570824d53d6c35ce94d73a46c8e98673a127bf08"
+  integrity sha512-NU7GWc265m92xh/aYD79Vr1W+zAIXDWp3L2YZOYP4rCqPnJ6LI6vh3+rKgkidtYijozHclaEQTAHaAaMWPVI4A==
+  dependencies:
+    prop-types "^15.7.2"
+
 react-router@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.0.tgz#424e75641ca8747fbf76e5ecca69781aa37ea293"


### PR DESCRIPTION
React Router Dom has a known problem with links that include a hash. The suggested solution is to use another library called react-router-hash-link (https://github.com/rafgraph/react-router-hash-link) that provides a HashLink component. I replaced the links in the dashboard sidenav with HashLinks. I also used the Semantic UI Menu components for the sidenav.