### PR TITLE
Add "View my scenarios" button to Recent Scenarios section

### DIFF
--- a/client/components/Dashboard/RecentScenarios.jsx
+++ b/client/components/Dashboard/RecentScenarios.jsx
@@ -10,6 +10,47 @@ import ScenarioCard from '@components/ScenariosList/ScenarioCard';
 import ScenarioDetailModal from '@components/ScenariosList/ScenarioDetailModal';
 import { getRecentScenarios } from '@actions/scenario';
 
+const CreateScenarioButton = () => {
+  return (
+    <Button
+      icon
+      primary
+      labelPosition="left"
+      name="Create a new scenario"
+      size="small"
+      href="/editor/new"
+      as="a"
+    >
+      <Icon name="add" />
+      Create a new scenario
+    </Button>
+  );
+};
+
+const ScenarioButtonGroup = () => {
+  const user = useSelector(state => state.user);
+  const permissions = useSelector(state => state.session.permissions);
+  const canCreateScenarios = permissions.includes('create_scenario');
+
+  return (
+    <Header.Subheader className="dashboard-subheader">
+      {canCreateScenarios && <CreateScenarioButton />}
+      <Button secondary size="small" href="/scenarios">
+        View all scenarios
+      </Button>
+      {canCreateScenarios ? (
+        <Button size="small" href={`/scenarios/author/${user.username}/`}>
+          View my scenarios
+        </Button>
+      ) : (
+        <RequestPermissionsLink>
+          I want to create scenarios →
+        </RequestPermissionsLink>
+      )}
+    </Header.Subheader>
+  );
+};
+
 const RecentScenarios = () => {
   const dispatch = useDispatch();
   const scenarios = useSelector(state => state.recentScenarios);
@@ -28,11 +69,6 @@ const RecentScenarios = () => {
     setOpen(false);
   };
 
-  const user = useSelector(state => state.user);
-
-  const permissions = useSelector(state => state.session.permissions);
-  const canCreateScenarios = permissions.includes('create_scenario');
-
   useEffect(() => {
     dispatch(getRecentScenarios());
   }, [dispatch]);
@@ -40,34 +76,7 @@ const RecentScenarios = () => {
   return (
     <Container fluid id="recent-scenarios">
       <Header as="h2">Your most recent scenarios</Header>
-      <Header.Subheader className="dashboard-subheader">
-        {canCreateScenarios && (
-          <Button
-            icon
-            primary
-            labelPosition="left"
-            name="Create a new scenario"
-            size="small"
-            href="/editor/new"
-            as="a"
-          >
-            <Icon name="add" />
-            Create a new scenario
-          </Button>
-        )}
-        <Button size="small" href="/scenarios">
-          View all scenarios
-        </Button>
-        {canCreateScenarios ? (
-          <Button size="small" href={`/scenarios/author/${user.username}/`}>
-            View my scenarios
-          </Button>
-        ) : (
-          <RequestPermissionsLink>
-            I want to create scenarios →
-          </RequestPermissionsLink>
-        )}
-      </Header.Subheader>
+      <ScenarioButtonGroup />
       {scenarios.length ? (
         <List className="dashboard-grid">
           {scenarios.map((scenario, index) => {

--- a/client/components/Dashboard/RecentScenarios.jsx
+++ b/client/components/Dashboard/RecentScenarios.jsx
@@ -28,6 +28,8 @@ const RecentScenarios = () => {
     setOpen(false);
   };
 
+  const user = useSelector(state => state.user);
+
   const permissions = useSelector(state => state.session.permissions);
   const canCreateScenarios = permissions.includes('create_scenario');
 
@@ -56,7 +58,11 @@ const RecentScenarios = () => {
         <Button size="small" href="/scenarios">
           View all scenarios
         </Button>
-        {!canCreateScenarios && (
+        {canCreateScenarios ? (
+          <Button size="small" href={`/scenarios/author/${user.username}/`}>
+            View my scenarios
+          </Button>
+        ) : (
           <RequestPermissionsLink>
             I want to create scenarios →
           </RequestPermissionsLink>


### PR DESCRIPTION
Having two gray buttons next to each other made it hard to distinguish them, so I made the "View all scenarios" button "secondary," which seems to have made it black. I think this looks fine for now but it's easily changed in the future.