### PR TITLE
Allow super admin to set special description for example scenarios

### DIFF
--- a/client/components/Dashboard/LearnByExample.jsx
+++ b/client/components/Dashboard/LearnByExample.jsx
@@ -35,7 +35,7 @@ const LearnByExample = () => {
                 <Card.Header as="h2">{scenario.title}</Card.Header>
                 <Card.Description>
                   <Text.Truncate lines={3}>
-                    {scenario.description}
+                    {scenario.example_description || scenario.description}
                   </Text.Truncate>
                 </Card.Description>
                 <Divider />

--- a/client/components/ScenarioEditor/index.jsx
+++ b/client/components/ScenarioEditor/index.jsx
@@ -448,6 +448,23 @@ class ScenarioEditor extends Component {
 
                   {user.is_super && makeExampleCheckbox}
 
+                  {user.is_super && scenario.is_example && (
+                    <Form.Field>
+                      <label htmlFor="example_description">
+                        Example Description
+                      </label>
+                      <Form.TextArea
+                        autoComplete="off"
+                        id="example_description"
+                        name="example_description"
+                        rows={2}
+                        placeholder="What does this scenario demonstrate about Teacher Moments?"
+                        value={scenario.example_description || ''}
+                        onChange={onChange}
+                      />
+                    </Form.Field>
+                  )}
+
                   {dropdowns}
 
                   {isNotNewScenario ? (
@@ -507,7 +524,8 @@ ScenarioEditor.propTypes = {
     status: PropTypes.number,
     title: PropTypes.string,
     users: PropTypes.array,
-    is_example: PropTypes.bool
+    is_example: PropTypes.bool,
+    example_description: PropTypes.string
   }),
   setScenario: PropTypes.func.isRequired,
   submitCB: PropTypes.func.isRequired,

--- a/client/reducers/scenarios.js
+++ b/client/reducers/scenarios.js
@@ -125,7 +125,8 @@ export const recentScenarios = (state = [], action) => {
       return recentScenarios;
     }
     case RESTORE_SCENARIO_SUCCESS:
-    case GET_SCENARIO_SUCCESS: {
+    case GET_SCENARIO_SUCCESS:
+    case SET_SCENARIO: {
       return updateExistingScenarioInState(state, scenario);
     }
     default: {
@@ -142,7 +143,8 @@ export const exampleScenarios = (state = [], action) => {
       return exampleScenarios;
     }
     case RESTORE_SCENARIO_SUCCESS:
-    case GET_SCENARIO_SUCCESS: {
+    case GET_SCENARIO_SUCCESS:
+    case SET_SCENARIO: {
       return updateExistingScenarioInState(state, scenario);
     }
     default: {

--- a/server/migrations/20220525134444-add-example-description.js
+++ b/server/migrations/20220525134444-add-example-description.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const sqlFile = require('./helpers/sql-file')(__filename);
+exports.up = function(db) {
+    return db.runSql(sqlFile.up);
+};
+exports.down = function(db) {
+    return db.runSql(sqlFile.down);
+};
+exports._meta = {
+    version: 1
+};

--- a/server/migrations/sql/20220525134444-add-example-description.sql
+++ b/server/migrations/sql/20220525134444-add-example-description.sql
@@ -1,0 +1,7 @@
+ALTER TABLE scenario
+  ADD COLUMN example_description TEXT;
+
+---
+
+ALTER TABLE scenario
+  DROP COLUMN example_description;

--- a/server/service/scenarios/endpoints.js
+++ b/server/service/scenarios/endpoints.js
@@ -144,7 +144,8 @@ async function setScenario(req, res) {
     personas,
     status,
     title,
-    is_example
+    is_example,
+    example_description
   } = req.body;
   const scenario_id = Number(req.params.scenario_id);
   let author_id = user.id;
@@ -160,7 +161,8 @@ async function setScenario(req, res) {
       description,
       status,
       title,
-      is_example
+      is_example,
+      example_description
     });
 
     await db.setScenarioCategories(scenario_id, categories);


### PR DESCRIPTION
If a scenario has been designated as an example, super admins can add an example description to explain what makes this scenario a good learning tool. This example description will appear on the dashboard in the Learn By Example section. 

https://app.asana.com/0/1199528021095056/1202324225921886