### PR TITLE
Differentiate scenario labels from tags

### DIFF
--- a/client/components/Cohorts/CohortCard.jsx
+++ b/client/components/Cohorts/CohortCard.jsx
@@ -1,6 +1,5 @@
 import { Button, Card } from '@components/UI';
 
-import CohortScenarioLabels from '@components/Cohorts/CohortScenarioLabels';
 import Identity from '@utils/Identity';
 import Moment from '@utils/Moment';
 import { NavLink } from 'react-router-dom';
@@ -54,9 +53,7 @@ export const CohortCard = props => {
         <Card.Meta title={`Created ${updatedCalendar}`}>
           Updated {updatedfromNow}
         </Card.Meta>
-        <Card.Description>
-          <CohortScenarioLabels cohort={cohort} />
-        </Card.Description>
+        <Card.Description>{props.children}</Card.Description>
       </Card.Content>
       {roles ? <Card.Content extra>{yourRoles}</Card.Content> : null}
       {restoreCohort}
@@ -70,7 +67,11 @@ CohortCard.propTypes = {
   history: PropTypes.object,
   roles: PropTypes.array,
   setCohort: PropTypes.func,
-  user: PropTypes.object
+  user: PropTypes.object,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ])
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/client/components/Cohorts/CohortScenarioLabels.jsx
+++ b/client/components/Cohorts/CohortScenarioLabels.jsx
@@ -51,6 +51,8 @@ class CohortScenarioLabels extends React.Component {
 
       if (filters.scenariosInUse.includes(value)) {
         labelProps.className = 'primary';
+      } else {
+        labelProps.basic = 'true';
       }
 
       accum.push(

--- a/client/components/Cohorts/index.jsx
+++ b/client/components/Cohorts/index.jsx
@@ -23,6 +23,7 @@ import {
 
 import CohortCard from './CohortCard';
 import CohortCreateWizard from './CohortCreateWizard';
+import CohortScenarioLabels from './CohortScenarioLabels';
 import CohortScenarioLabelsFilter from './CohortScenarioLabelsFilter';
 import Gate from '@components/Gate';
 import History from '@utils/History';
@@ -356,11 +357,18 @@ export class Cohorts extends React.Component {
     );
 
     const isSliceAvailable = cohortsSlice.length > 0;
-    const cards = isSliceAvailable
-      ? cohortsSlice.map(({ id }) => (
-          <CohortCard key={Identity.key({ id })} id={id} />
-      ))
-      : null;
+
+    let cards = null;
+
+    if (isSliceAvailable) {
+      cards = cohortsSlice.map(cohort => {
+        return (
+          <CohortCard key={Identity.key({ id: cohort.id })} id={cohort.id}>
+            <CohortScenarioLabels cohort={cohort} />
+          </CohortCard>
+        );
+      });
+    }
 
     const loadingProps = {
       card: { cols: itemsPerRow, rows: rowsPerPage, style: { height: '20rem' } }

--- a/client/components/Dashboard/RecentCohorts.jsx
+++ b/client/components/Dashboard/RecentCohorts.jsx
@@ -1,17 +1,43 @@
 import './Dashboard.css';
 
-import { Button, Icon } from '@components/UI';
+import { Button, Icon, Label } from '@components/UI';
 import { Container, Header, List, Segment } from '@components/UI';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import CohortCard from '../Cohorts/CohortCard';
 import CohortCreateWizard from '@components/Cohorts/CohortCreateWizard';
+import Identity from '@utils/Identity';
+import PropTypes from 'prop-types';
 import RequestPermissionsLink from './RequestPermissionsLink';
 import { SCENARIO_IS_PUBLIC } from '@components/Scenario/constants';
 import { getRecentCohorts } from '@actions/cohort';
 import { getScenariosByStatus } from '@actions/scenario';
 import { isParticipantOnly } from '@utils/Roles';
+
+const NonClickableCohortScenarios = ({ cohort }) => {
+  const scenariosById = useSelector(state => state.scenariosById);
+
+  const labels = cohort.scenarios.reduce((collection, id) => {
+    const scenario = scenariosById[id];
+
+    if (scenario) {
+      collection.push(
+        <Label basic size="small" key={Identity.key({ scenario, cohort })}>
+          {scenario.title}
+        </Label>
+      );
+    }
+
+    return collection;
+  }, []);
+
+  return <Label.Group>{labels}</Label.Group>;
+};
+
+NonClickableCohortScenarios.propTypes = {
+  cohort: PropTypes.object
+};
 
 const RecentCohorts = () => {
   const dispatch = useDispatch();
@@ -72,7 +98,9 @@ const RecentCohorts = () => {
           {cohorts.map(cohort => {
             return (
               <List.Item key={cohort.id}>
-                <CohortCard id={cohort.id} />
+                <CohortCard id={cohort.id}>
+                  <NonClickableCohortScenarios cohort={cohort} />
+                </CohortCard>
               </List.Item>
             );
           })}


### PR DESCRIPTION
Use 'basic' label design for scenario labels on cohort card. On the dashboard page, where filtering cohorts by scenario is not possible, make the scenario labels non-clickable.